### PR TITLE
set dir parameter if not already set so that tests are more repeatable if the use save()

### DIFF
--- a/lib/Test/RedisServer.pm
+++ b/lib/Test/RedisServer.pm
@@ -49,6 +49,10 @@ sub BUILD {
         $self->conf->{port} = '0';
     }
 
+    unless (defined $self->conf->{dir}) {
+        $self->conf->{dir} = "$tmpdir/";
+    }
+
     if ($self->conf->{loglevel} and $self->conf->{loglevel} eq 'warning') {
         warn "Test::RedisServer does not support \"loglevel warning\", using \"notice\" instead.\n";
         $self->conf->{loglevel} = 'notice';


### PR DESCRIPTION
this prevents a surprise dump.rdb file appearing in $CWD if the test
happens to call $redis->save().  on subsequent runs, that dump will be
reloaded and you won't be running with an empty instance.

default dir to the tmpdir so that it gets automatically cleaned up after
testing
