### PR TITLE
Update regexp for redis error messages.

### DIFF
--- a/t/unknown_conf.t
+++ b/t/unknown_conf.t
@@ -14,6 +14,6 @@ eval {
 };
 
 ok !$server, 'server did not initialize ok';
-like $@, qr/\*\*\* FATAL CONFIG FILE ERROR \*\*\*/, 'error msg ok';
+like $@, qr/\*\*\* FATAL CONFIG FILE ERROR/, 'error msg ok';
 
 done_testing;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test-RedisServer.
We thought you might be interested in it too.

    Description: Update regexp for redis error messages.
     With redis 6.0.5 t/unknown_conf.t fails with
     # *** FATAL CONFIG FILE ERROR (Redis 6.0.5) ***
     #     doesn't match '(?^:\*\*\* FATAL CONFIG FILE ERROR \*\*\*)'
     Update regexp to match older and newer variantes.
    Origin: vendor
    Bug-Debian:: https://bugs.debian.org/963357
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2020-06-21
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtest-redisserver-perl/raw/master/debian/patches/redis-error-message.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
