### PR TITLE
Minor update to tests to cope with a more diverse set of error messages

### DIFF
--- a/t/unknown_conf.t
+++ b/t/unknown_conf.t
@@ -14,6 +14,6 @@ eval {
 };
 
 ok !$server, 'server did not initialize ok';
-like $@, qr/\*\*\* FATAL CONFIG FILE ERROR \*\*\*/, 'error msg ok';
+like $@, qr/\*\*\* FATAL CONFIG FILE ERROR( \([^\)]+\))? \*\*\*/, 'error msg ok';
 
 done_testing;


### PR DESCRIPTION
My build of redis-server fails with a slightly different error message than what the tests expect:

  t/unknown_conf.t .. 1/?
  #   Failed test 'error msg ok'
  #   at t/unknown_conf.t line 17.
  #                   '*** failed to launch redis-server ***
  #
  # *** FATAL CONFIG FILE ERROR (Redis 6.0.6) ***
  # Reading the configuration file, at line 4
  # >>> 'unknown_key unknown_val'
  # Bad directive or wrong number of arguments
  #  at t/unknown_conf.t line 11.
  # '
  #     doesn't match '(?^:\*\*\* FATAL CONFIG FILE ERROR \*\*\*)'
  # Looks like you failed 1 test of 2.
  t/unknown_conf.t .. Dubious, test returned 1 (wstat 256, 0x100)
  Failed 1/2 subtests

I've updated the regex to also accept any (string in parentheses) in that position.