### PR TITLE
Adjust test to redis 8.0.0

### DIFF
--- a/t/unknown_conf.t
+++ b/t/unknown_conf.t
@@ -15,6 +15,6 @@ eval {
 
 ok !$server, 'server did not initialize ok';
 
-like $@, qr/\*\*\* FATAL CONFIG FILE ERROR( \([^\)]+\))? \*\*\*/, 'error msg ok';
+like $@, qr/(?:\*\*\* FATAL CONFIG FILE ERROR( \([^\)]+\))? \*\*\*|Module Configuration detected without loadmodule directive or no ApplyConfig call: aborting)/, 'error msg ok';
 
 done_testing;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test-RedisServer.
We thought you might be interested in it too.

    Description: Adjust test to redis 8.0.0
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1106425
    Author: Chris Lamb <lamby@debian.org>
    Reviewed-by: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-05-29
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtest-redisserver-perl/raw/master/debian/patches/1106425.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
