### PR TITLE
fix the tmpdir existence check in stop to use -d instead of -f

### DIFF
--- a/lib/Test/RedisServer.pm
+++ b/lib/Test/RedisServer.pm
@@ -183,7 +183,7 @@ sub stop {
     # It is unlikely that tmpdir will disappear first, but if both the RedisServer
     # object and the tmpdir are defined globally, it may happen because the order
     # in which they are DESTLOYed is uncertain.
-    if (! -f $self->tmpdir) {
+    if (! -d $self->tmpdir) {
         $self->_redis->config_set('appendonly', 'no');
         $self->_redis->config_set('save', '');
     }

--- a/t/no_save.t
+++ b/t/no_save.t
@@ -15,7 +15,7 @@ subtest 'stop does not block when tmpdir is removed before stop' => sub {
     ok $server->pid, 'pid ok';
 
     remove_tree($tmpdir);
-    ok ! -f $tmpdir;
+    ok ! -d $tmpdir;
 
     $server->stop;
     pass 'redis exit ok';

--- a/t/no_save.t
+++ b/t/no_save.t
@@ -1,20 +1,36 @@
 use strict;
 use warnings;
 use Test::More;
+use File::Temp;
 use File::Path 'remove_tree';
+use Redis;
 
 use Test::RedisServer;
 
 eval { Test::RedisServer->new } or plan skip_all => 'redis-server is required in PATH to run this test';
 
-my $tmpdir = File::Temp->newdir;
-my $server = Test::RedisServer->new(tmpdir => $tmpdir);
-ok $server->pid, 'pid ok';
+subtest 'stop does not block when tmpdir is removed before stop' => sub {
+    my $tmpdir = File::Temp->newdir;
+    my $server = Test::RedisServer->new(tmpdir => $tmpdir);
+    ok $server->pid, 'pid ok';
 
-remove_tree($tmpdir);
-ok ! -f $tmpdir;
+    remove_tree($tmpdir);
+    ok ! -f $tmpdir;
 
-$server->stop;
-pass 'redis exit ok';
+    $server->stop;
+    pass 'redis exit ok';
+};
+
+subtest 'normal stop saves dump.rdb when tmpdir exists' => sub {
+    my $tmpdir = File::Temp->newdir;
+    my $server = Test::RedisServer->new(tmpdir => $tmpdir);
+    ok $server->pid, 'pid ok';
+
+    my $redis = Redis->new($server->connect_info);
+    $redis->set(foo => 'bar');
+
+    $server->stop;
+    ok -f "$tmpdir/dump.rdb", 'dump.rdb is created on normal stop';
+};
 
 done_testing;


### PR DESCRIPTION
@Songmu san

https://github.com/typester/Test-RedisServer/blob/1529153baaec806389edc29838c7a2c16db5dcde/lib/Test/RedisServer.pm#L186 ,

`tmpdir` is always a directory, so the `-f` check was never true and the save
config was cleared on every stop — a normal stop never saved `dump.rdb`. The
test added in 58d7d37 reproduces this.

4dfb7e3 switches the check to `-d` so the save config is cleared only when the
tmpdir is actually gone (the blocking case #15 guards against). Both the
existing abnormal case and the added normal case pass.

---

By the way — I noticed the GitHub Actions run has no redis-server available, so every test that requires it is skipped and only t/no_server.t actually runs:

```
t/basic.t ......... skipped: redis-server is required in PATH to run this test
t/manual_start.t .. skipped: redis-server is required in PATH to run this test
t/no_save.t ....... skipped: redis-server is required in PATH to run this test
t/no_server.t ..... ok
t/tmp_dir.t ....... skipped: redis-server is required in PATH to run this test
t/unknown_conf.t .. skipped: redis-server is required in PATH to run this test
t/wait.t .......... skipped: redis-server is required in PATH to run this test
All tests successful.
```

https://github.com/typester/Test-RedisServer/actions/runs/27598814620/job/81595188238

Is this intentional? If not, I'd be happy to add a step that installs redis-server.